### PR TITLE
fix: allow passing any string other than file path to Configration.js…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on Rails, config/initializers/fcmpush.rb
 Fcmpush.configure do |config|
   ## for message push
   # firebase web console => project settings => service account => firebase admin sdk => generate new private key
-  config.json_key_io = "#{Rails.root}/path/to/service_account_credentials.json"
+  config.json_key_io = File.open("#{Rails.root}/path/to/service_account_credentials.json") # Or, give the json string directly (for example, from your Key-Value Store)
 
   # Or set environment variables
   # ENV['GOOGLE_ACCOUNT_TYPE'] = 'service_account'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ on Rails, config/initializers/fcmpush.rb
 Fcmpush.configure do |config|
   ## for message push
   # firebase web console => project settings => service account => firebase admin sdk => generate new private key
-  config.json_key_io = File.open("#{Rails.root}/path/to/service_account_credentials.json") # Or, give the json string directly (for example, from your Key-Value Store)
+
+  # pass string of path to credential file to config.json_key_io
+  config.json_key_io = "#{Rails.root}/path/to/service_account_credentials.json"
+  # Or content of json key file wrapped with StringIO
+  # config.json_key_io = StringIO.new('{ ... }')
 
   # Or set environment variables
   # ENV['GOOGLE_ACCOUNT_TYPE'] = 'service_account'

--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -26,7 +26,7 @@ module Fcmpush
     def v1_authorize
       @auth ||= if configuration.json_key_io
                   Google::Auth::ServiceAccountCredentials.make_creds(
-                    json_key_io: File.open(configuration.json_key_io),
+                    json_key_io: configuration.json_key_io,
                     scope: configuration.scope
                   )
                 else

--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -25,8 +25,13 @@ module Fcmpush
 
     def v1_authorize
       @auth ||= if configuration.json_key_io
+                  io = if configuration.json_key_io.is_a?(IO)
+                    configuration.json_key_io
+                  else
+                    File.open(configuration.json_key_io)
+                  end
                   Google::Auth::ServiceAccountCredentials.make_creds(
-                    json_key_io: configuration.json_key_io,
+                    json_key_io: io,
                     scope: configuration.scope
                   )
                 else


### PR DESCRIPTION
This PR includes breaking changes.

I use this gem for my app with multi-tenancy features.
FCM private keys for each tenant has been stored in KVS.

In the current implementation, `json_key_io` only accept the file path of the FCM private key,
but we want to pass the contents of the json key directly from KVS to the parameter.

I have removed `File.open` in `v1_authorize` method for more flexibility.

