### PR TITLE
fix: `subscribe` and `unsubscribe` methods not working

### DIFF
--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -122,7 +122,7 @@ module Fcmpush
       def legacy_authorized_header(headers)
         headers.merge('Content-Type' => 'application/json',
                       'Accept' => 'application/json',
-                      'Authorization' => "Bearer key=#{server_key}")
+                      'Authorization' => "Bearer #{server_key}")
       end
 
       def exception_handler(response)


### PR DESCRIPTION
Hi, there.

`subscribe` and `unsubscribe` methods haven't worked since last week.

They return a ~404~ 401 status.

failed rspec.
```
1) Fcmpush Fcmpush::Client #subscribe subscribe test
    Failure/Error: raise error.new("Receieved an error response #{response.code} #{error.to_s.split('::').last}: #{response.body}", response) if error
    
    Fcmpush::Unauthorized:
    Receieved an error response 401 Unauthorized: <HTML>
    <HEAD>
    <TITLE>Unauthorized</TITLE>
    </HEAD>
    <BODY BGCOLOR="#FFFFFF" TEXT="#000000">
    <H1>Unauthorized</H1>
    <H2>Error 401</H2>
    </BODY>
    </HTML>
    # ./lib/fcmpush/client.rb:132:in `exception_handler'
    # ./lib/fcmpush/client.rb:60:in `subscribe'
    # ./spec/fcmpush_spec.rb:60:in `block (4 levels) in <top (required)>'

Finished in 6.5 seconds (files took 0.67857 seconds to load)
1 example, 1 failure
```

Perhaps, it doesn't work if there is a `key=` in the Authentication to be included in the headers.
Removing this made it work.

refs:
https://firebase.google.com/support/faq?hl=en#fcm-depr-features
https://firebase.google.com/docs/cloud-messaging/migrate-v1?hl=en#after-send-auth
