### PR TITLE
fix: server_key deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Fcmpush.configure do |config|
 
   ## for topic subscribe/unsubscribe because they use regacy auth
   # firebase web console => project settings => cloud messaging => Project credentials => Server key
+  # @deprecated: This attribute will be removed next version.
   config.server_key = 'your firebase server key'
   # Or set environment variables
+  # @deprecated: This attribute will be removed next version.
   # ENV['FCM_SERVER_KEY'] = 'your firebase server key'
 
   # Proxy ENV variables are considered by default if set by net/http, but you can explicitly define your proxy host here

--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -112,7 +112,10 @@ module Fcmpush
         uri = URI.join(TOPIC_DOMAIN, TOPIC_ENDPOINT_PREFIX + suffix)
         uri.query = URI.encode_www_form(query) unless query.empty?
 
-        headers = legacy_authorized_header(headers)
+        headers = v1_authorized_header(headers)
+        # cf. https://takanamito.hateblo.jp/entry/2020/07/04/175045
+        # cf. https://github.com/miyataka/fcmpush/issues/40
+        headers['access_token_auth'] = 'true'
         post = Net::HTTP::Post.new(uri, headers)
         post.body = make_subscription_body(topic, *instance_ids)
 

--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -23,7 +23,7 @@ module Fcmpush
       access_token_response = v1_authorize
       @access_token = access_token_response['access_token']
       @access_token_expiry = Time.now.utc + access_token_response['expires_in']
-      @server_key = configuration.server_key
+      # @server_key = configuration.server_key
       @connection = Net::HTTP::Persistent.new
 
       if !configuration.proxy
@@ -136,7 +136,9 @@ module Fcmpush
                       'Authorization' => "Bearer #{access_token}")
       end
 
+      # @deprecated TODO: remove this method next version
       def legacy_authorized_header(headers)
+        warn "[DEPRECATION] `legacy_authorized_header` is deprecated.  Please use `v1_authorized_header` instead."
         headers.merge('Content-Type' => 'application/json',
                       'Accept' => 'application/json',
                       'Authorization' => "Bearer #{server_key}")

--- a/lib/fcmpush/configuration.rb
+++ b/lib/fcmpush/configuration.rb
@@ -15,7 +15,11 @@ module Fcmpush
       # ENV['GOOGLE_PRIVATE_KEY'] = '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n'
 
       # regacy auth
+      # @deprecated TODO: remove this next version
       @server_key = ENV['FCM_SERVER_KEY']
+      if @server_key
+        warn '[DEPRECATION] `FCM_SERVER_KEY` environment variable, also @server_key is deprecated. This attribute will be removed next version.'
+      end
 
       # THIS IS EXPERIMENTAL
       # NOT support `HTTPS_PROXY` environment variable. This feature not tested well on CI.


### PR DESCRIPTION
fix: https://github.com/miyataka/fcmpush/issues/40

Server_key is deprecated. So, it was NOT used any more.