### PR TITLE
add http connection open and read timeout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Fcmpush.configure do |config|
   # config.proxy = { uri: "http://proxy.host:3128", user: nil, password: nil }
   # explicitly disable using proxy, even ignore environment variables if set
   # config.proxy = false
+
+  # HTTP connection open and read timeouts (in seconds) are set for all client requests.
+  # If unset, the default values for Net::HTTP::Persistent are used (currently 60 seconds).
+  # config.open_timeout = 30
+  # config.read_timeout = 15
 end
 ```
 

--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -26,6 +26,9 @@ module Fcmpush
       # @server_key = configuration.server_key
       @connection = Net::HTTP::Persistent.new
 
+      @connection.open_timeout = configuration.open_timeout if configuration.open_timeout
+      @connection.read_timeout = configuration.read_timeout if configuration.read_timeout
+
       if !configuration.proxy
         # do nothing
       elsif configuration.proxy == :ENV

--- a/lib/fcmpush/configuration.rb
+++ b/lib/fcmpush/configuration.rb
@@ -1,6 +1,6 @@
 module Fcmpush
   class Configuration
-    attr_accessor :scope, :json_key_io, :server_key, :proxy
+    attr_accessor :scope, :json_key_io, :server_key, :proxy, :open_timeout, :read_timeout
 
     def initialize
       @scope = ['https://www.googleapis.com/auth/firebase.messaging']
@@ -26,6 +26,10 @@ module Fcmpush
       # cf. https://github.com/miyataka/fcmpush/pull/39#issuecomment-1722533622
       # proxy
       @proxy = :ENV
+
+      # connection timeouts
+      @open_timeout = nil
+      @read_timeout = nil
     end
   end
 end


### PR DESCRIPTION
Add support for HTTP connection open and read timeouts. The default values for `Net::HTTP::Persistent` are 60 seconds currently and are a little too high for my use case.