### PR TITLE
Add deprecation warning and raise exception for batch_push

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ json = response.json
 json[:name] # => "projects/[your_project_id]/messages/0:1571037134532751%31bd1c9631bd1c96"
 ```
 
-### push messages in batch
+### push messages in batch [DEPRECATED]
 ```ruby
 require 'fcmpush'
 

--- a/lib/fcmpush/client.rb
+++ b/lib/fcmpush/client.rb
@@ -87,12 +87,15 @@ module Fcmpush
       raise NetworkError, "A network error occurred: #{e.class} (#{e.message})"
     end
 
+    #-------------------------------------------------------------------------------
+    # BATCH REQUESTS DEPRECATED BY GOOGLE ON June 20,2023 AND SHUTDOWN ON June 21, 2024
+    # https://firebase.google.com/support/faq/#fcm-depr-features
+    # 
+    # Until upgrading to use HTTP/2, warning and throwing error
+    #-------------------------------------------------------------------------------
     def batch_push(messages, query: {}, headers: {})
-      uri, request = make_batch_request(messages, query, headers)
-      response = exception_handler(connection.request(uri, request))
-      BatchResponse.new(response)
-    rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
-      raise NetworkError, "A network error occurred: #{e.class} (#{e.message})"
+      warn '[DEPRECATION] `batch_push` is deprecated.  Please use `push` for each message instead.'
+      raise DeprecatedApiError, 'BATCH REQUESTS DEPRECATED BY GOOGLE ON June 20,2023 AND SHUTDOWN ON June 21, 2024 (https://firebase.google.com/support/faq/#fcm-depr-features)'
     end
 
     private

--- a/lib/fcmpush/exceptions.rb
+++ b/lib/fcmpush/exceptions.rb
@@ -1,5 +1,6 @@
 module Fcmpush
   class APIError < StandardError; end
+  class DeprecatedApiError < StandardError; end
   class NetworkError < APIError; end
 
   class HttpError < APIError

--- a/spec/fcmpush_spec.rb
+++ b/spec/fcmpush_spec.rb
@@ -78,23 +78,22 @@ RSpec.describe Fcmpush do
     end
 
     context '#batch_push' do
-      it 'batch test' do
-        client = Fcmpush.new(project_id)
-        message_jsons = 5.times.map do |i|
-          { message: { token: device_token,
-                       notification: { title: "test title#{i}",
-                                       body: "test body#{i}" } } }
-        end
-        response = client.batch_push(message_jsons)
-
-        json = response.json
-
-        expect(response.code).to eq('200')
-        expect(response.success_count).to eq(5)
-        expect(response.failure_count).to eq(0)
-        expect(json.length).to eq(5)
-        result = json.all? { |i| i[:name]&.start_with?("projects/#{project_id}/messages/") }
-        expect(result).to be true
+      it 'raises DeprecatedApiError' do
+        expect do
+          client = Fcmpush.new(project_id)
+          message_jsons = 5.times.map do |i|
+            {
+              message: {
+                token: device_token,
+                notification: {
+                  title: "test title#{i}",
+                  body: "test body#{i}"
+                }
+              }
+            }
+          end
+          client.batch_push(message_jsons)
+        end.to raise_error(Fcmpush::DeprecatedApiError)
       end
     end
   end


### PR DESCRIPTION
As pointed out in the issue https://github.com/miyataka/fcmpush/issues/45 Google has shutdown sending message in batch without HTTP/2

Before removing completely the method i just set it to raise and exception and print out a warning but maybe can be completely removed?